### PR TITLE
Use Locale.ROOT for converting types to lowercase in PitchforkBlock.

### DIFF
--- a/src/main/java/com/github/mim1q/convenientdecor/block/PitchforkBlock.java
+++ b/src/main/java/com/github/mim1q/convenientdecor/block/PitchforkBlock.java
@@ -1,5 +1,7 @@
 package com.github.mim1q.convenientdecor.block;
 
+import java.util.Locale;
+
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.ShapeContext;
@@ -66,7 +68,7 @@ public class PitchforkBlock extends Block {
 
     @Override
     public String asString() {
-      return name().toLowerCase();
+      return name().toLowerCase(Locale.ROOT);
     }
   }
 }


### PR DESCRIPTION
This prevents an issue faced by players with the turkish language, as an uppercase I is changed to a lowercase dotless ı in that locale, which is not a valid character for block property names.

Attached is a crash report of one of the players having that issue.
For searchability here is the error message: `Block{minecraft:air} has property: type with invalidly named value: straıght`

[crash-2024-06-22_19.54.02-client.txt](https://github.com/user-attachments/files/15937916/crash-2024-06-22_19.54.02-client.txt)

Edit: as a workaround players can add `-Duser.language=en` to their Java arguments.
